### PR TITLE
prevent progress report from hanging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,12 @@
       <version>1.4</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+	  <groupId>com.jayway.awaitility</groupId>
+	  <artifactId>awaitility</artifactId>
+	  <version>1.6.5</version>
+	  <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/src/main/java/org/sonar/squidbridge/ProgressAstScanner.java
+++ b/src/main/java/org/sonar/squidbridge/ProgressAstScanner.java
@@ -40,7 +40,12 @@ public class ProgressAstScanner<G extends Grammar> extends AstScanner<G> {
   @Override
   public void scanFiles(Collection<File> files) {
     progressReport.start(files);
-    super.scanFiles(files);
+    try {
+      super.scanFiles(files);
+    } catch (Throwable t) {
+      progressReport.cancel();
+      throw t;
+    }
     progressReport.stop();
   }
 

--- a/src/main/java/org/sonar/squidbridge/ProgressReport.java
+++ b/src/main/java/org/sonar/squidbridge/ProgressReport.java
@@ -36,6 +36,7 @@ public class ProgressReport implements Runnable {
   private Iterator<File> it;
   private final Thread thread;
   private final String adjective;
+  private boolean success = false;
 
   public ProgressReport(String threadName, long period, Logger logger, String adjective) {
     this.period = period;
@@ -43,6 +44,7 @@ public class ProgressReport implements Runnable {
     this.adjective = adjective;
     thread = new Thread(this);
     thread.setName(threadName);
+    thread.setDaemon(true);
   }
 
   public ProgressReport(String threadName, long period, String adjective) {
@@ -62,11 +64,13 @@ public class ProgressReport implements Runnable {
           log(currentFileNumber + "/" + count + " files " + adjective + ", current file: " + currentFile.getAbsolutePath());
         }
       } catch (InterruptedException e) {
-        thread.interrupt();
+        break;
       }
     }
     synchronized (this) {
-      log(count + "/" + count + " source files have been " + adjective);
+      if (success) {
+        log(count + "/" + count + " source files have been " + adjective);
+      }
     }
   }
 
@@ -88,6 +92,11 @@ public class ProgressReport implements Runnable {
   }
 
   public synchronized void stop() {
+    success = true;
+    thread.interrupt();
+  }
+
+  public synchronized void cancel() {
     thread.interrupt();
   }
 

--- a/src/test/java/org/sonar/squidbridge/ProgressReportTest.java
+++ b/src/test/java/org/sonar/squidbridge/ProgressReportTest.java
@@ -40,7 +40,7 @@ public class ProgressReportTest {
   @Rule
   public final Timeout timeout = new Timeout(5000);
 
-  @Test
+  @Test(timeout=5000)
   public void test() throws Exception {
     Logger logger = mock(Logger.class);
 
@@ -72,6 +72,23 @@ public class ProgressReportTest {
       assertThat(messages.get(i)).isEqualTo("0/2 files analyzed, current file: foo");
     }
     assertThat(messages.get(messages.size() - 1)).isEqualTo("2/2" + " source files have been analyzed");
+  }
+  
+  @Test(timeout=5000)
+  public void testCancel() throws InterruptedException {
+    Logger logger = mock(Logger.class);
+
+    ProgressReport report = new ProgressReport(ProgressReport.class.getName(), 100, logger, "analyzed");
+    File file = mock(File.class);
+    when(file.getAbsolutePath()).thenReturn("foo");
+    report.start(ImmutableList.of(file, file));
+    
+    // Wait for start message
+    waitForMessage(logger);
+    
+    report.cancel();
+    report.join();
+    
   }
 
   private static void waitForMessage(Logger logger) throws InterruptedException {


### PR DESCRIPTION
The same class was used in sonar-batch and caused it to hang if there was an error before stop() was called.