### PR TITLE
Remove use of deprecated 'org.sonar.check.Cardinality'

### DIFF
--- a/src/main/java/org/sonar/squidbridge/annotations/AnnotationBasedRulesDefinition.java
+++ b/src/main/java/org/sonar/squidbridge/annotations/AnnotationBasedRulesDefinition.java
@@ -24,20 +24,23 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import java.lang.annotation.Annotation;
+import java.net.URL;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
+import java.util.Set;
 import org.apache.commons.lang.StringUtils;
-import org.sonar.api.server.rule.*;
+import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinition.NewParam;
 import org.sonar.api.server.rule.RulesDefinition.NewRepository;
 import org.sonar.api.server.rule.RulesDefinition.NewRule;
+import org.sonar.api.server.rule.RulesDefinitionAnnotationLoader;
 import org.sonar.api.utils.AnnotationUtils;
-import org.sonar.check.Cardinality;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
 import org.sonar.squidbridge.rules.ExternalDescriptionLoader;
-
-import java.lang.annotation.Annotation;
-import java.net.URL;
-import java.util.*;
 
 /**
  * Utility class which helps setting up an implementation of {@link RulesDefinition} with a list of
@@ -126,9 +129,6 @@ public class AnnotationBasedRulesDefinition {
     NewRule rule = repository.rule(ruleKey);
     if (rule == null) {
       throw new IllegalStateException("No rule was created for " + ruleClass + " in " + repository);
-    }
-    if (ruleAnnotation.cardinality() == Cardinality.MULTIPLE) {
-      throw new IllegalArgumentException("Cardinality is not supported, use the RuleTemplate annotation instead");
     }
     return rule;
   }

--- a/src/test/java/org/sonar/squidbridge/annotations/AnnotationBasedRulesDefinitionTest.java
+++ b/src/test/java/org/sonar/squidbridge/annotations/AnnotationBasedRulesDefinitionTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.sonar.api.server.debt.DebtRemediationFunction;
 import org.sonar.api.server.debt.DebtRemediationFunction.Type;
-import org.sonar.api.server.rule.*;
+import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinition.NewRepository;
 import org.sonar.api.server.rule.RulesDefinition.Param;
 import org.sonar.api.server.rule.RulesDefinition.Repository;
@@ -146,16 +146,6 @@ public class AnnotationBasedRulesDefinitionTest {
 
     RulesDefinition.Rule rule = buildSingleRuleRepository(RuleClass.class);
     assertThat(rule.template()).isFalse();
-  }
-
-  @Test
-  public void cardinality_multiple() throws Exception {
-    @Rule(key = "key1", name = "name1", description = "description1", cardinality = Cardinality.MULTIPLE)
-    class RuleClass {
-    }
-
-    thrown.expect(IllegalArgumentException.class);
-    buildSingleRuleRepository(RuleClass.class);
   }
 
   @Test


### PR DESCRIPTION
As started by [SONAR-10235](https://jira.sonarsource.com/browse/SONAR-10235), first step in order to remove some deprecated API, leading eventually to release of new version of sslr-squid-bridge.